### PR TITLE
feat: add docs section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,7 @@ bun dev
   - For unix systems `OLLAMA_ORIGINS=https://slatechat.vercel.app ollama serve`
   - For powershell `$env:OLLAMA_ORIGINS="https://slatechat.vercel.app"; ollama serve`
 - Go to https://slatechat.vercel.app/chat and start a new local chat, you should see your models listed in the dropdown
+
+![image](https://github.com/user-attachments/assets/9155eda5-88e2-4ad1-8e87-2474709b3e42)
+
 > If you're using the Brave browser or any other ad blockers, don't forget to disable the ad blocking or it won't work.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,20 @@
 ## Development
 
 ### Running locally
-
 ```sh
 bun install
 bun dev
 ```
+
+
+## Docs 
+> This will be replaced by dedicated documentation later.
+
+
+### How to setup `ollama` locally 
+- Setup `ollama` following the documentation on https://ollama.com/download
+- Choose any model or models from `https://ollama.com/search` that you wanna run and pull them using `ollama pull <MODEL_NAME>`
+- Run one of the following commands to start `ollama` locally
+  - For unix systems `OLLAMA_ORIGINS=https://slatechat.vercel.app ollama serve`
+  - For powershell `$env:OLLAMA_ORIGINS="https://slatechat.vercel.app"; ollama serve`
+- Go to https://slatechat.vercel.app/chat and start a new local chat, you should see your models listed in the dropdown

--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ bun dev
   - For unix systems `OLLAMA_ORIGINS=https://slatechat.vercel.app ollama serve`
   - For powershell `$env:OLLAMA_ORIGINS="https://slatechat.vercel.app"; ollama serve`
 - Go to https://slatechat.vercel.app/chat and start a new local chat, you should see your models listed in the dropdown
+> If you're using the Brave browser or any other ad blockers, don't forget to disable the ad blocking or it won't work.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Introduced a new "Docs" section outlining steps for setting up the service locally.
	- Detailed instructions now guide users through configuring their environment and starting a local instance on both Unix and PowerShell systems.
	- Added a note regarding potential issues with ad blockers when accessing local chat features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->