### PR TITLE
fix: update model list when new model is added

### DIFF
--- a/src/lib/components/ui/chat/new-chat.svelte
+++ b/src/lib/components/ui/chat/new-chat.svelte
@@ -27,7 +27,7 @@
 
 	type ChatFormData = z.infer<typeof chatFormSchema>;
 
-	let modelOptions = $state<{ value: string; label: string }[]>();
+	let modelOptions = $state<{ value: string; label: string }[]>([]);
 	let selectedModel = $state<{ value: string; label: string } | undefined>(undefined);
 	let formErrors = $state<Record<string, string>>({});
 	let formData = $state<ChatFormData>({
@@ -97,17 +97,36 @@
 		toast.success(`New chat "${formData.title}" created`);
 	}
 
-	onMount(() => {
+	function updateModelOptions() {
 		if ($modelStore.length > 0) {
 			modelOptions = $modelStore.map((model) => ({
 				value: model.id,
 				label: `${model.title} (${model.name}, ${model.temperature})`
 			}));
-			selectedModel = modelOptions[0];
-			if (selectedModel) {
+
+			if (!selectedModel && modelOptions.length > 0) {
+				selectedModel = modelOptions[0];
 				formData.modelId = selectedModel.value;
 			}
+		} else {
+			modelOptions = [];
+			selectedModel = undefined;
+			formData.modelId = '';
 		}
+	}
+
+	$effect(() => {
+		if ($metaStore.showChatForm) {
+			updateModelOptions();
+		}
+	});
+
+	$effect(() => {
+		updateModelOptions();
+	});
+
+	onMount(() => {
+		updateModelOptions();
 	});
 
 	let { children } = $props();


### PR DESCRIPTION
## ISSUE 
When a new model is added and the new chat form is opened, the model doesn't show up because of a bug in the new chat form `modelOption` logic, which only loads the list when the component is mounted. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- The chat form now refreshes its available model selections automatically when the form loads and as related settings change.
	- Default options are properly set when models are available, and selections are cleared when no options exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->